### PR TITLE
CI: replace phpdbg with php in coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary
- run coverage with \ instead of deprecated \
- keep the existing tester coverage target intact otherwise

## Motivation
- resolves contributte/contributte#73 for this repository

## Testing
- [x] make -n coverage
- [ ] full test suite