### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
     coverage:
         name: "Phpunit"
         uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+        secrets: inherit
         with:
             php: "8.4"
             make: "init coverage"


### PR DESCRIPTION
## What changed

- Added `secrets: inherit` to `.github/workflows/coverage.yml` so the reusable coverage workflow receives required secrets.

## Why

- This rollout completes contributte/contributte#74 for `contributte/gui-skeleton` and keeps coverage jobs working with the shared workflow setup.